### PR TITLE
Added feature to enable extracting database type from DBContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# AWS X-Ray SDK for .NET and .NET Core
+# AWS X-Ray SDK for Entity Framework Core 3.0 and above
 
 ![Screenshot of the AWS X-Ray console](images/example_servicemap.png?raw=true)
 
 ## Installing
 
-The AWS X-Ray SDK for .NET and .NET Core (.netstandard 2.0 and above) is in the form of Nuget packages. You can install the packages from [Nuget](https://www.nuget.org/packages?q=AWSXRayRecorder) gallery or from Visual Studio editor. Search `AWSXRayRecorder*` to see various middlewares available.  
+For installing AWS X-Ray SDK for .NET and .NET Core, please take reference to [Link](https://github.com/aws/aws-xray-sdk-dotnet#aws-x-ray-sdk-for-net-and-net-core)
 
 ## Getting Help
 
@@ -32,331 +32,37 @@ Following API reference documentation provides guidance for using the SDK and mo
 * AWS X-Ray SDK Documentation for [.NET SDK](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet.html)
 * [Sample Apps](https://github.com/aws-samples/aws-xray-dotnet-webapp)
 
-## Quick Start
+## Entity Framework Core Support 
 
-1. [Configuration](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#configuration)
-2. [ASP.NET Core Framework](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#aspnet-core-framework-net-core--nuget)
-3. [ASP.NET Framework](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#aspnet-framework-net--nuget)
-4. [Trace AWS SDK request](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#trace-aws-sdk-request-net-and-net-core--nuget) 
-5. [Trace out-going HTTP requests](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#trace-out-going-http-requests-net-and-net-core--nuget)
-6. [Trace Query to SQL Server](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#trace-query-to-sql-server-net-and-net-core--nuget)
-7. [Multithreaded Execution](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#multithreaded-execution-net-and-net-core--nuget)
-8. [Trace custom methods ](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#trace-custom-methods-net-and-net-core)
-9. [Creating custom Segment/Subsegment](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#creating-custom-segmentsubsegment-net-and-net-core)
-10. [Adding metadata/annotations](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#adding-metadataannotations-net-and-net-core)
-11. [AWS Lambda support (.NET Core)](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#aws-lambda-support-net-core)
-12. [ASP.NET Core on AWS Lambda](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#aspnet-core-on-aws-lambda-net-core)
-13. [Logging](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#logging-net)
-14. [Enabling X-Ray on Elastic Beanstalk](https://docs.aws.amazon.com/xray/latest/devguide/xray-services-beanstalk.html)
-15. [Enabling X-Ray on AWS Lambda](https://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html)
+We support tracing sql request generated through Entity Framework Core platform using `EFInterceptor`. 
 
-## Configuration
+### ASP.NET Core on Entity Framework Core (.NET Core)
 
-### .NET
+For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/intro?view=aspnetcore-3.1&tabs=visual-studio)
 
-You can configure X-Ray in the `appsettings` of your `App.config` or `Web.config` file.
+Due to the fact that not all database provider support Entity Framework 3.0 and above, currently 
+`EFInterceptor` can only trace sql queries towards: SqlServer, MySQL, SQLite, PostgreSQL and FireBird. Please make sure that you are using the Nuget package with a supportive provider and with a correct version (EF Core >= 3.0).
 
-```xml
-<configuration>
-  <appSettings>
-    <add key="DisableXRayTracing" value="false"/>
-    <add key="AWSXRayPlugins" value="EC2Plugin, ECSPlugin, ElasticBeanstalkPlugin"/>
-    <add key="SamplingRuleManifest" value="JSONs\DefaultSamplingRules.json"/>
-    <add key="AwsServiceHandlerManifest" value="JSONs\AWSRequestInfo.json"/>
-    <add key="UseRuntimeErrors" value="true"/>
-    <add key="CollectSqlQueries" value="false"/>
-  </appSettings>
-</configuration>
-```
+#### Setup
 
-### .NET Core
-
-Following are the steps to configure your .NET Core project with X-Ray.
-
-a) In `appsettings.json` file, configure items under `XRay` key
+In order to trace sql queries, you can register `DBContext` with `EFInterceptor` in the `startup.cs` file. For instance, when dealing with MySql server using Nuget: [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql) 
 
 ```
-{
-  "XRay": {
-    "DisableXRayTracing": "false",
-    "SamplingRuleManifest": "SamplingRules.json",
-    "AWSXRayPlugins": "EC2Plugin, ECSPlugin, ElasticBeanstalkPlugin",
-    "AwsServiceHandlerManifest": "JSONs\AWSRequestInfo.json",
-    "UseRuntimeErrors":"true",
-    "CollectSqlQueries":"false"
-  }
-}
-```
+public void ConfigureServices(IServiceCollection services){ 
 
-b) Register `IConfiguration` instance with X-Ray:
+services.AddDbContext<YourDbContext>(options => options.UseMySql(connectionString).AddInterceptors(new EFInterceptor()));
 
-```csharp
-using Amazon.XRay.Recorder.Core;
-AWSXRayRecorder.InitializeInstance(configuration); // pass IConfiguration object that reads appsettings.json file
-```
-
-*Note*:  
-1. You should configure this before initialization of `AWSXRayRecorder` instance and using any AWS X-Ray methods.  
-2. If you manually need to configure `IConfiguration` object refer: [Link](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?tabs=basicconfiguration)  
-3. For more information on configuration, please refer : [Link](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-configuration.html)
-
-### Programmatic Configuration (.NET and .NET Core)
-
-Alternatively, you can also set up the `AWSXRayRecorder` instance programmatically by using the `AWSXRayRecorderBuilder` class instead of a configuration file. 
-For initializing an AWSXRayRecorder instance with default configurations, simply do the following.
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();
-AWSXRayRecorder.InitializeInstance(recorder: recorder);
-```
-
-The following code initializes an `AWSXRayRecorder` instance with a custom `IStreamingStrategy` and a custom `ISamplingStrategy`. 
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().WithStreamingStrategy(new CustomStreamingStrategy()).WithSamplingStrategy(CustomSamplingStrategy()).Build();
-AWSXRayRecorder.InitializeInstance(recorder: recorder);
-```
-
-*Note*:
-1. `CustomStreamingStrategy` and `CustomSamplingStrategy` must implement `IStreamingStrategy` and `ISamplingStrategy` before being used to build the `recorder`.
-2. `recorder` must be instantiated using `AWSXRayRecorder.InitializeInstance(recorder: recorder)` before being used in the program. 
-
-
-
-
-## How to Use
-
-### Incoming Requests
-
-### ASP.NET Core Framework (.NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.AspNetCore/)
-
-You can instrument X-Ray for your `ASP.NET Core` App in the `Configure()` method of `Startup.cs` file of your project.  
-*Note* :  
-1. For .Net Core 2.1 and above, use `app.UseXRay()` middleware **before** any other middleware to trace incoming requests. For .Net Core 2.0 place the `app.UseXRay()` middleware **after** the `app.UseExceptionHandler("/Error")` in order to catch exceptions. You would be able to see any runtime exception with its stack trace, however, the status code might show 200 due to a known limitation of the ExceptionHandler middleware in .Net Core 2.0. 
-2. You need to install `AWSXRayRecorder.Handlers.AspNetCore` nuget package. This package adds extension methods to the `IApplicationBuilder` to make it easy to register AWS X-Ray to the ASP.NET Core HTTP pipeline.
-
-A) With default configuration:
-
-* For .Net Core 2.1 and above: 
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-
-public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-{
-    app.UseXRay("SampleApp"); // name of the app
-    app.UseExceptionHandler("/Error");
-    app.UseStaticFiles(); // rest of the middlewares
-    app.UseMVC();
-}
-```
-
-* For .Net Core 2.0: 
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-
-public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-{
-    app.UseExceptionHandler("/Error");
-    app.UseXRay("SampleApp"); // name of the app
-    app.UseStaticFiles(); // rest of the middlewares
-    app.UseMVC();
-}
-```
-
-B) With custom X-Ray configuration  
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-
-public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-{
-    app.UseExceptionHandler("/Error");
-    app.UseXRay("SampleApp",configuration); // IConfiguration object is not required if you have used "AWSXRayRecorder.InitializeInstance(configuration)" method
-    app.UseStaticFiles(); // rest of the middlewares
-    app.UseMVC();	
-}
-```
-
-Instead of name you can also pass `SegmentNamingStrategy` in the above two ways. Please refer: [Link](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-messagehandler.html#xray-sdk-dotnet-messagehandler-naming)  
-
-### ASP.NET Framework (.NET) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.AspNet/) 
-
-**HTTP Message handler for ASP.NET framework**  
-Register your application with X-Ray in the `Init()` method of ***Global.asax*** file
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.AspNet;
-
-public class MvcApplication : System.Web.HttpApplication
-{
-     public override void Init()
-     {
-        base.Init();
-        AWSXRayASPNET.RegisterXRay(this, "ASPNETTest"); // default name of the web app
-     }
-}
-```
-
-At the start of each Http request, a `segment` is created and stored in the `context` (Key : AWSXRayASPNET.XRayEntity) of `HttpApplication` instance. If users write their custom error handler for ASP.NET framework, they can access `segment` for the current request by following way : 
-
-```csharp
-<%@ Import Namespace="Amazon.XRay.Recorder.Handlers.AspNet" %>
-<%@ Import Namespace="Amazon.XRay.Recorder.Core.Internal.Entities" %>
-<script runat="server">
-  protected void Page_Load(object sender, EventArgs e)
-  {
-     var context = System.Web.HttpContext.Current.ApplicationInstance.Context;
-     var segment = (Segment) context.Items[AWSXRayASPNET.XRayEntity]; // get segment from the context
-     segment.AddMetadata("Error","404");
-  }
-</script>
-```
-
-### Trace AWS SDK request (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.AwsSdk/)
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.AwsSdk;
-
-AWSSDKHandler.RegisterXRayForAllServices(); //place this before any instantiation of AmazonServiceClient
-AmazonDynamoDBClient client = new AmazonDynamoDBClient(RegionEndpoint.USWest2); // AmazonDynamoDBClient is automatically registered with X-Ray
-```
-
-Methods of `AWSSDKHandler` class:
-
-```csharp
-AWSSDKHandler.RegisterXRayForAllServices(); // all instances of AmazonServiceClient created after this line are registered
-
-AWSSDKHandler.RegisterXRay<IAmazonDynamoDB>(); // Registers specific type of AmazonServiceClient : All instances of IAmazonDynamoDB created after this line are registered
-
-AWSSDKHandler.RegisterXRayManifest(String path); // To configure custom AWS Service Manifest file. This is optional, if you have followed "Configuration" section
-```
-
-### Trace out-going HTTP requests (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.System.Net/)
-
-#### Using `System.Net.HttpWebRequest`
-
-#### Synchronous request
-
-An extension method `GetResponseTraced()` is provided to trace `GetResponse()` in `System.Net.HttpWebRequest` class. If you want to trace the out-going HTTP request, call the `GetResponseTraced()` instead of `GetResponse()`. The extension method will generate a trace subsegment, inject the trace header to the out-going HTTP request header and collect trace information. 
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.System.Net;
-
-HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desired url
-
-// Any other configuration to the request
-
-request.GetResponseTraced();
-```
-
-#### Asynchronous request
-
-An extension method `GetAsyncResponseTraced()` is provided to trace `GetResponseAsync()` in `System.Net.HttpWebRequest` class. If you want to trace the out-going HTTP request, call the `GetAsyncResponseTraced()` instead of `GetResponseAsync()`. The extension method will generate a trace subsegment, inject the trace header to the out-going HTTP request header and collect trace information. 
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.System.Net;
-
-HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desired url
-
-// Any other configuration to the request
-
-request.GetAsyncResponseTraced();
-```
-
-#### Using `System.Net.HttpClient`
-
-A handler derived from `DelegatingHandler` is provided to trace the `HttpMessageHandler.SendAsync` method
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.System.Net;
-
-var httpClient = new HttpClient(new HttpClientXRayTracingHandler(new HttpClientHandler()));
-
-// Any other configuration to the client
-
-httpClient.GetAsync(URL);
-```
-
-#### Using `System.Net.Http.HttpClientFactory` (.Net Core 2.1 and above)
-
-The `Amazon.XRay.Recorder.Handlers.System.Net` package includes a delegate that can be used to trace outbound requests without the need to specifically wrap outbound requests from that class.
-
-Register the `HttpClientXRayTracingHandler` as a middleware for your http client.
-
-```csharp
-services.AddHttpClient<IFooClient, FooClient>()
-        .AddHttpMessageHandler<HttpClientXRayTracingHandler>();
-```
-or
-
-```csharp
-services.AddHttpClient("foo")
-        .ConfigurePrimaryHttpMessageHandler(() =>
-        {
-            return new HttpClientXRayTracingHandler(new HttpClientHandler());
-        });
-```
-
-Use the above client factory to create clients with outgoing requests traced.
-
-```csharp
-var client = _clientFactory.CreateClient("foo");
-var request = new HttpRequestMessage(HttpMethod.Get, "https://www.foobar.com");
-var response = await client.SendAsync(request);
-```
-
-### Trace Query to SQL Server (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.SqlServer/)
-
-The SDK provides a wrapper class for `System.Data.SqlClient.SqlCommand`. The wrapper class can be used interchangable with `SqlCommand` class. By replacing instance of `SqlCommand` to `TraceableSqlCommand`, synchronized/asynchronized method will automatically generate subsegment for the SQL query.
-
-Following examples illustrate the use of `TraceableSqlCommand` to automatically trace SQL Server queries using Synchronous/Asynchronous methods:
-
-#### Synchronous query
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.SqlServer;
-
-using (var connection = new SqlConnection("fake connection string"))
-using (var command = new TraceableSqlCommand("SELECT * FROM products", connection))
-{
-    command.ExecuteNonQuery();
-}
-```
-
-#### Asynchronous query
-
-```csharp
-using Amazon.XRay.Recorder.Handlers.SqlServer;
-
-using (var connection = new SqlConnection(ConnectionString))
-{
-    var command = new TraceableSqlCommand("SELECT * FROM Products FOR XML AUTO, ELEMENTS", connection);
-    command.Connection.Open();
-    await command.ExecuteXmlReaderAsync();
 }
 ```
 
 #### Capture SQL Query text in the traced SQL calls to SQL Server
 
- You can also opt in to capture the `SqlCommand.CommandText` as part of the subsegment created for your SQL query. The collected `SqlCommand.CommandText` will appear as `sanitized_query` in the subsegment JSON. By default, this feature is disabled due to security reasons. If you want to enable this feature, it can be done in two ways. First, by setting the `CollectSqlQueries` to `true` in the global configuration for your application as follows:
-
-##### For .Net (In `appsettings` of your `App.config` or `Web.config` file)
-
-```xml
-<configuration>
-  <appSettings>
-    <add key="CollectSqlQueries" value="true">
-  </appSettings>
-</configuration>
-```
+You can also opt in to capture the `DBCommand.CommandText` as part of the subsegment created for your SQL query. The collected `DBCommand.CommandText` will appear as `sanitized_query` in the subsegment JSON. By default, this feature is disabled due to security reasons. 
+If you want to enable this feature, it can be done in two ways. First, by setting the `CollectSqlQueries` to true in the global configuration for your application as follows:
 
 ##### For .Net Core (In `appsettings.json` file, configure items under XRay key)
 
-```json
+```
 {
   "XRay": {
     "CollectSqlQueries":"true"
@@ -364,252 +70,21 @@ using (var connection = new SqlConnection(ConnectionString))
 }
 ```
 
-This will enable X-Ray to collect all the sql queries made to SQL Server by your application.
+Secondly, you can set the `collectSqlQueries` parameter in the `EFInterceptor` instance as true to collect the SQL query text for SQL Server query calls made using this instance. If you set this parameter as false, it will disable the `CollectSqlQuery` feature for this `EFInterceptor` instance.
 
-Secondly, you can set the `collectSqlQueries` parameter in the `TraceableSqlCommand` instance as `true` to collect the SQL query text for SQL Server query calls made using this instance. If you set this parameter as `false`, it will disable the CollectSqlQuery feature for this `TraceableSqlCommand` instance.
+```
+public void ConfigureServices(IServiceCollection services){
 
-```csharp
-using Amazon.XRay.Recorder.Handlers.SqlServer;
+services.AddDbContext<YourDbContext>(options => options.UseMySql(connectionString).AddInterceptors(new EFInterceptor(true)));
 
-using (var connection = new SqlConnection("fake connection string"))
-using (var command = new TraceableSqlCommand("SELECT * FROM products", connection, collectSqlQueries: true))
-{
-    command.ExecuteNonQuery();
 }
 ```
 
-*NOTE:* 
-1. You should **not** enable either of these properties if you are including sensitive information as clear text in your SQL queries.
+NOTE:
+
+1. You should not enable either of these properties if you are including sensitive information as clear text in your SQL queries.
 2. Parameterized values will appear in their tokenized form and will not be expanded.
-3. The value of `collectSqlQueries` in the `TraceableSqlCommand` instance overrides the value set in the global configuration using the `CollectSqlQueries` property.
-
-### Multithreaded Execution (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Core/)
-
-In multithreaded execution, X-Ray context from current to its child thread is automatically set.  
-
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-private static void TestMultiThreaded()
-{
-    int numThreads = 3;
-    AWSXRayRecorder.Instance.BeginSegment("MainThread");
-    Thread[] t= new Thread[numThreads];
- 
-    for(int i = 0; i < numThreads; i++)
-    {
-    	t[i] = new Thread(()=>MakeHttpRequest(i)); 
-        t[i].Start();
-    }
-    for (int i = 0; i < numThreads; i++)
-    {
-        t[i].Join();
-    }
-
-    AWSXRayRecorder.Instance.EndSegment();
-}
-
-private static void MakeHttpRequest(int i)
-{
-    AWSXRayRecorder.Instance.TraceMethodAsync("Thread "+i, CreateRequestAsync<HttpResponseMessage>).Wait();
-}
-
-private static async Task<HttpResponseMessage> CreateRequestAsync <TResult>()
-{
-    var request = new HttpClient();
-    var result = await request.GetAsync(URL); // Enter desired url
-    return result;
-}
-```
-
-*Note*:
-1. Context used to save traces in .NET : [CallContext](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.remoting.messaging.callcontext?view=netframework-4.5)
-2. Context used to save traces in .NET Core : [AsyncLocal](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1?view=netcore-2.0)
-
-### Trace custom methods (.NET and .NET Core)
-
-It may be useful to further decorate portions of an application for which performance is critical. Generating subsegments around these hot spots will help in understanding their impact on application performance.
-
-#### Synchronous method
-
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-AWSXRayRecorder.Instance.TraceMethod("custom method", () => DoSomething(arg1, arg2, arg3));
-```
-
-#### Asynchronous method
-
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-var response = await AWSXRayRecorder.Instance.TraceMethodAsync("AddProduct", () => AddProduct<Document>(product));
-
-private async Task<Document> AddProduct <TResult>(Product product)
-{
-    var document = new Document();
-    document["Id"] = product.Id;
-    document["Name"] = product.Name;
-    document["Price"] = product.Price;
-    return await LazyTable.Value.PutItemAsync(document);
-}
-```
-
-### Creating custom Segment/Subsegment (.NET and .NET Core)
-
-#### Segment
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-AWSXRayRecorder.Instance.BeginSegment("segment name"); // generates `TraceId` for you
-try
-{
-    DoSometing();
-    // can create custom subsegments
-}
-catch (Exception e)
-{
-    AWSXRayRecorder.Instance.AddException(e);
-}
-finally
-{
-    AWSXRayRecorder.Instance.EndSegment();
-}
-```
-
-If you want to pass custom `TraceId`:
-
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-String traceId = TraceId.NewId(); // This function is present in : Amazon.XRay.Recorder.Core.Internal.Entities
-AWSXRayRecorder.Instance.BeginSegment("segment name",traceId); // custom traceId used while creating segment
-try
-{
-    DoSometing();
-    // can create custom subsegments
-}
-catch (Exception e)
-{
-    AWSXRayRecorder.Instance.AddException(e);
-}
-finally
-{
-    AWSXRayRecorder.Instance.EndSegment();
-}
-```
-
-#### Subsegment
-
-*Note*: This should only be used after `BeginSegment()` method.  
-```csharp
-using Amazon.XRay.Recorder.Core;
-
-AWSXRayRecorder.Instance.BeginSubsegment("subsegment name");
-try
-{
-    DoSometing();
-}
-catch (Exception e)
-{
-    AWSXRayRecorder.Instance.AddException(e);
-}
-finally
-{
-    AWSXRayRecorder.Instance.EndSubsegment();
-}
-```
-
-
-
-### Adding metadata/annotations (.NET and .NET Core)
-
-```csharp
-using Amazon.XRay.Recorder.Core;
-AWSXRayRecorder.Instance.AddAnnotation("mykey", "my value");
-AWSXRayRecorder.Instance.AddMetadata("my key", "my value");
-```
-
-### AWS Lambda support (.NET Core) 
-The AWS Lambda execution environment by default creates a `Segment` before each Lambda function invocation and sends it to the X-Ray service. AWS X-Ray .NET/Core SDK will make sure there will be a `FacadeSegment` inside the lambda context so that you can instrument your application successfully through subsegments only. `Subsegments` generated inside a Lambda function are attached to this `FacadeSegment` and only subsegments are streamed by the SDK. In addition to the custom subsegments, the middlewares would generate subsegments for outgoing HTTP calls, SQL queries, and AWS SDK calls within the lambda function the same way they do in a normal application.
-
-*Note*: You can only create and close `Subsegment` inside a lambda function. `Segment` cannot be created inside the lambda function. All operations on `Segment` will throw an `UnsupportedOperationException` exception.
-
-```csharp
-public string FunctionHandler(string input, ILambdaContext context)
-{
-    AWSXRayRecorder recorder = new AWSXRayRecorder();
-    recorder.BeginSubsegment("UpperCase");
-    recorder.BeginSubsegment("Inner 1");
-    String result = input?.ToUpper();
-    recorder.EndSubsegment();
-    recorder.BeginSubsegment("Inner 2");
-    recorder.EndSubsegment();
-    recorder.EndSubsegment();
-    return result;
-}
-```
-
-### ASP.NET Core on AWS Lambda (.NET Core)
-
-We support instrumenting ASP.NET Core web app on Lambda. Please follow the steps of [ASP.NET Core](https://github.com/aws/aws-xray-sdk-dotnet/tree/master#aspnet-core-framework-net-core--nuget) instrumentation.
-
-### Logging (.NET)
-
-The AWS X-Ray .NET SDK share the same logging mechanism as AWS .NET SDK. If the application had already configured logging for AWS .NET SDK, it should just work for AWS X-Ray .NET SDK.
-The recommended way to configure an application is to use the <aws> element in the project’s `App.config` or `Web.config` file.
-
-```xml
-<configuration>
-  <configSections>
-    <section name="aws" type="Amazon.AWSSection, AWSSDK.Core"/>
-  </configSections>
-  <aws>
-    <logging logTo="Log4Net"/>
-  </aws>
-</configuration>
-```
-
-Other ways to configure logging is to edit the <appsetting> element in the `App.config` or `Web.config` file, and set property values in the `AWSConfig` class. Refer to the following page for more details and example : [Link](http://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config.html)
-
-
-### Logging (.NET Core)
-
-Currently we support `log4net` logging and options provided in [LoggingOptions](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TLoggingOptions.html). You should configure logging before initialization of `AWSXRayRecorder` instance or using any X-Ray methods.  
-Following is the way to configure logging with X-Ray SDK:
-
-```csharp
-using Amazon;
-using Amazon.XRay.Recorder.Core;
-
-class Program
-{
-    static Program()
-    {
-         AWSXRayRecorder.RegisterLogger(LoggingOptions.Log4Net); // Log4Net instance should already be configured before this point
-    }
-}
-``` 
-
-log4net.config example:
-
-```xml
-<?xml version="1.0" encoding="utf-8" ?>
-<log4net>
-  <appender name="FileAppender" type="log4net.Appender.FileAppender,log4net">
-    <file value="c:\logs\sdk-log.txt" />
-    <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="%date [%thread] %level %logger - %message%newline" />
-    </layout>
-  </appender>
-  <logger name="Amazon">
-    <level value="DEBUG" />
-    <appender-ref ref="FileAppender" />
-  </logger>
-</log4net>
-```
-
-*Note*: For `log4net` configuration, refer : [Link](https://logging.apache.org/log4net/release/manual/configuration.html)
+3. The value of `collectSqlQueries` in the `EFInterceptor` instance overrides the value set in the global configuration using the CollectSqlQueries property.
 
 ## License
 

--- a/sdk/AWSXRayRecorder.sln
+++ b/sdk/AWSXRayRecorder.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.Handlers.As
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.Handlers.EntityFramework", "src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj", "{8C95F2F0-3098-4189-8D05-B2517086AC39}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleEBASPNETCoreApplication", "..\..\..\sample-app\aws-xray-dotnet-webapp\DotNETCore\SampleEBASPNETCoreApplication.csproj", "{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,6 +90,12 @@ Global
 		{8C95F2F0-3098-4189-8D05-B2517086AC39}.Nuget|Any CPU.Build.0 = Release|Any CPU
 		{8C95F2F0-3098-4189-8D05-B2517086AC39}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C95F2F0-3098-4189-8D05-B2517086AC39}.Release|Any CPU.Build.0 = Release|Any CPU
+		{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}.Nuget|Any CPU.ActiveCfg = Debug|Any CPU
+		{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}.Nuget|Any CPU.Build.0 = Debug|Any CPU
+		{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{400DA36F-CF14-4F26-ABE6-8C3B09AACE54}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
*Issue #, if available:*

Trace sql queries through Entity Framework Core 3.0 and above.

*Description of changes:*

Added code to enable extracting database type from DBContext.

Updated `README.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
